### PR TITLE
Resolve JSON serialization bug of SQLAlchemy row object

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -76,7 +76,11 @@ def check_for_changes(last_stored_items, scraped_items):
 def get_changes():
     """ Function that returns the changes from database """
 
-    last_change = Changes.query.order_by(Changes.id.desc()).first()
+    last_change_row_object = Changes.query.order_by(Changes.id.desc()).first()
+    last_change = {}
+    for column in last_change_row_object.__table__.columns:
+        last_change[column.name] = str(
+            getattr(last_change_row_object, column.name))
 
     return last_change
 


### PR DESCRIPTION
Previously,  the `get_changes()` function returned the SQLAlchemy row object and that was used in the return value of a `GET` request to `/` for the server app. However, this row object is not JSON serialiize-able which caused an error. This change adds a simple loop to construct a dictionary from the row object and have `get_changes` return this new dictionary. 