### PR TITLE
Add init fn to table models 

### DIFF
--- a/server/models.py
+++ b/server/models.py
@@ -14,11 +14,10 @@ class Listings(db.Model):
     expiration = db.Column(db.DateTime, nullable=False)
     items = db.Column(db.JSON, nullable=False)
 
-    def __init__(self, items, timestamp=None, expiration=None):
-        self.timestamp = timestamp
+    def __init__(self, items, expiration=None):
+        self.items = items
         self.expiration = expiration if expiration else calculate_expiration_date(
             7)
-        self.items = items
 
     @classmethod
     def add_record(self, items):
@@ -39,11 +38,10 @@ class Changes(db.Model):
     expiration = db.Column(db.DateTime, nullable=False)
     items = db.Column(db.JSON, nullable=False)
 
-    def __init__(self, items, timestamp=None, expiration=None):
-        self.timestamp = timestamp
+    def __init__(self, items, expiration=None):
+        self.items = items
         self.expiration = expiration if expiration else calculate_expiration_date(
             7)
-        self.items = items
 
     @classmethod
     def add_record(self, items):

--- a/server/models.py
+++ b/server/models.py
@@ -11,9 +11,14 @@ class Listings(db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-    expiration = db.Column(db.DateTime, nullable=False,
-                           default=calculate_expiration_date(7))
+    expiration = db.Column(db.DateTime, nullable=False)
     items = db.Column(db.JSON, nullable=False)
+
+    def __init__(self, items, timestamp=None, expiration=None):
+        self.timestamp = timestamp
+        self.expiration = expiration if expiration else calculate_expiration_date(
+            7)
+        self.items = items
 
     @classmethod
     def add_record(self, items):
@@ -34,6 +39,12 @@ class Changes(db.Model):
     expiration = db.Column(db.DateTime, nullable=False,
                            default=calculate_expiration_date(365))
     items = db.Column(db.JSON, nullable=False)
+
+    def __init__(self, items, timestamp=None, expiration=None):
+        self.timestamp = timestamp
+        self.expiration = expiration if expiration else calculate_expiration_date(
+            7)
+        self.items = items
 
     @classmethod
     def add_record(self, items):

--- a/server/models.py
+++ b/server/models.py
@@ -36,8 +36,7 @@ class Changes(db.Model):
 
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
     timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-    expiration = db.Column(db.DateTime, nullable=False,
-                           default=calculate_expiration_date(365))
+    expiration = db.Column(db.DateTime, nullable=False)
     items = db.Column(db.JSON, nullable=False)
 
     def __init__(self, items, timestamp=None, expiration=None):

--- a/server/models.py
+++ b/server/models.py
@@ -41,7 +41,7 @@ class Changes(db.Model):
     def __init__(self, items, expiration=None):
         self.items = items
         self.expiration = expiration if expiration else calculate_expiration_date(
-            7)
+            365)
 
     @classmethod
     def add_record(self, items):


### PR DESCRIPTION
Previously, the expiration column had a default value of `datenow.utcnow() + timedelta(n_days)`. The intention of this value is that whenever a new row is created in the table, the value will be a certain number of days after the timestamp of creation. However, what actually happened is that setting the default value this way was calling the value for the first entry, and setting the same timestamp value every subsequent entry. 

![image](https://user-images.githubusercontent.com/69769431/217411656-9b51b9ae-cb85-4ba8-8fe2-fe270301128b.png)
- Here you can see that all entries have the same expiration timestamp despite having different creation timestamps.

By utilizing `__init__` functions for the tables, the expiration timestamp value calculation function will be treated as a callback function properly such that a new expiration timestamp value is generated for every record.