### PR TITLE
Fix changes key error

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -99,9 +99,7 @@ def scrape_mynintendo():
     new_item = Listings.add_record(results)
     db.session.commit()  # wrap in a try/catch?
 
-    if changes:
-        return changes
-    else:
+    if not changes:
         changes = "No changes."
 
     return {"changes": changes, "timestamp": new_item.timestamp}


### PR DESCRIPTION
If there were changes detected in the scrape results, previously would return the change results directly rather than setting it as a value in the changes key. This caused accessing errors in the `app.py` file due to the route trying to access `results['changes']` to determine if Discord needs to be notified.