### PR TITLE
Resolve bug with changed values dictionary being displayed

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -67,7 +67,8 @@ def check_for_changes(last_stored_items, scraped_items):
         if difference == "values_changed":
             changed_items = []
             for item in diff[difference]:
-                changed_items.append({item[6:-2]: diff[difference][item]})
+                changed_items.append(
+                    {item[6:-2]: f'{diff[difference][item]["new_value"]} (Old value: {diff[difference][item]["old_value"]})'})
             changes["Changed Items"] = changed_items
 
     return changes


### PR DESCRIPTION
Previously, if an item had it's price changed (which happens if it goes out of stock), the dictionary that is built to display this information used the raw value output from the `deepdiff` library:
```
"changes": {
   "Changed Items": [
      {
         "ITEM_NAME": 
            {
                "new_value": "Out of stock",
                "old_value": "OLD_PRICE"
            }
      }
   ] 
}
```

This caused an error on the React frontend as it tries to put an object as a child of a node, which isn't allowed. This PR fixes this issue by changing the value for the item key to be a just a string: 

```
"changes": {
   "Changed Items": [
      {
         "ITEM_NAME": "[new_value] ([old_value])
      }
   ] 
}
```
