### PR TITLE
Add no cache headers

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -10,9 +10,10 @@ import dotenv
 dotenv.load_dotenv()
 
 url = "https://www.nintendo.com/store/exclusives/rewards/"
+headers = {'Cache-Control': 'no-cache, must-revalidate'}
 
 # get the text from the provided url
-html_text = requests.get(url).text
+html_text = requests.get(url, headers=headers).text
 
 
 def check_items():


### PR DESCRIPTION
Currently, the deployed app doesn't detect changes unless it's redeployed. This leads me to suspect the page is being cached. In an attempt to overcome this, a `header` for forcing the requests to re-validate is being added.