### PR TITLE
Update name target element to not be hard coded

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -25,7 +25,10 @@ def check_items():
     items = soup.find_all(
         'div', class_=re.compile('BasicTilestyles__Info-sc'))
     for item in items:
-        name = item.div.h3.text if item.div.h3 else item.div.h2.text
+        # the website changes what header is used (e.g. h2, h3) so need a non hard coded way to target it via find_next()
+        header = item.div.find_next()
+        name = header.text
+        print(name)
         stock = item.find(
             'div', class_=re.compile('ProductTilestyles__DescriptionTag-sc'))  # checks if the item has "Out of Stock" label
 


### PR DESCRIPTION
Fixes issue #22.

The website changes the `header` tag used to display the name of the items, requiring updating the function each time based on the changes as it was hardcoded in the function `check_items`. However, instead of targeting the header directly, such as `item.div.h2.text`, `BeautifulSoup` has a function `find_next()` which returns the [next sibling element](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all-next-and-find-next). By using this approach instead, as long as a header is always the next element, then there is no need to specify whether or not the name of the item is displayed via a specific `h` tag. 