### PR TITLE
Clarify naming of changes key

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,7 +11,7 @@ import ItemGrid from "./components/ItemGrid";
 import Changes from "./components/Changes";
 
 interface IScrapeResults {
-  changes: IChanges;
+  recent_change: IChanges;
   current_listings: IItems;
   last_change: ILastChange;
 }
@@ -48,7 +48,7 @@ function App() {
           <Box paddingBottom={1}>
             <Typography variant="h6">
               Last Checked:{" "}
-              {new Date(scrapeResults.changes.timestamp).toLocaleString()}
+              {new Date(scrapeResults.recent_change.timestamp).toLocaleString()}
             </Typography>
             <Button onClick={loadScrapeResults}>Scrape Again</Button>
             <Button>
@@ -62,7 +62,7 @@ function App() {
             </Button>
           </Box>
           <Changes
-            changes={scrapeResults.changes}
+            recentChange={scrapeResults.recent_change}
             lastChange={scrapeResults.last_change}
           ></Changes>
           <ItemGrid listings={scrapeResults.current_listings} />

--- a/app/src/components/Changes.tsx
+++ b/app/src/components/Changes.tsx
@@ -3,19 +3,19 @@ import { ChangedItemsList } from "./ChangedItemsList";
 import { IChanges, ILastChange } from "../interfaces/interfaces";
 
 interface ChangesProps {
-  changes: IChanges;
+  recentChange: IChanges;
   lastChange: ILastChange;
 }
 
-export default function Changes({ changes, lastChange }: ChangesProps) {
+export default function Changes({ recentChange, lastChange }: ChangesProps) {
   return (
     <Box sx={{ display: "flex", justifyContent: "center" }}>
       <Paper sx={{ maxWidth: 1 / 2, marginRight: 1, padding: 1 }}>
         <Typography>Latest Scrape Results:</Typography>
-        {typeof changes.changes === "string" ? (
-          <Typography variant="h6"> {changes.changes}</Typography>
+        {typeof recentChange.items === "string" ? (
+          <Typography variant="h6"> {recentChange.items}</Typography>
         ) : (
-          <ChangedItemsList changedItemsData={changes.changes} />
+          <ChangedItemsList changedItemsData={recentChange.items} />
         )}
       </Paper>
       <Paper sx={{ maxWidth: 1 / 2, marginLeft: 1, padding: 1 }}>

--- a/app/src/interfaces/interfaces.ts
+++ b/app/src/interfaces/interfaces.ts
@@ -7,7 +7,7 @@ export interface IScrapedItems {
 }
 
 export interface IChanges {
-  changes: IScrapedItems | string;
+  items: IScrapedItems | string;
   timestamp: string;
 }
 

--- a/server/app.py
+++ b/server/app.py
@@ -30,12 +30,12 @@ def show_home_page():
     scrape_results = scrape_mynintendo()
     last_change = get_changes()
 
-    if scrape_results["changes"] != "No changes.":
-        message_discord(scrape_results["changes"])
+    if scrape_results["items"] != "No changes.":
+        message_discord(scrape_results["items"])
 
     display = {
         "current_listings": items,
-        "changes": scrape_results,
+        "recent_change": scrape_results,
         "last_change": last_change
     }
     return jsonify(display)

--- a/server/main.py
+++ b/server/main.py
@@ -108,7 +108,7 @@ def scrape_mynintendo():
     if not changes:
         changes = "No changes."
 
-    return {"changes": changes, "timestamp": new_item.timestamp}
+    return {"items": changes, "timestamp": new_item.timestamp}
 
 
 def message_discord(changes):


### PR DESCRIPTION
Update the dictionary returned from the API to be less confusing, from `{changes : changes{} ...}` to `{ recent_change: items: {}...} `. This allows for the front end to be less confusing with accessing these values by avoiding having to type `changes.changes`. In addition, this makes the data structure for latest scrape results to be more consistent with last change.