### PR TITLE
Fix outdated key accessing

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -45,8 +45,8 @@ def show_home_page():
 def call_scrape_fn():
     results = scrape_mynintendo()
 
-    if results["changes"] != "No changes.":
-        message_discord(results["changes"])
+    if results["items"] != "No changes.":
+        message_discord(results["items"])
 
     return results
 


### PR DESCRIPTION
The key accessed in `api/scrape` was not updated to reflect recent changes in the returned dictionary from `scrape_mynintendo()`. This PR fixes this bug. 