### PR TITLE
Update `check_items` to handle CSS tag changes

### DIFF
--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -4,9 +4,6 @@ import react from "@vitejs/plugin-react"
 
 export default defineConfig(() => {
   return {
-    build: {
-      outDir: 'build',
-    },
     plugins: [react()],
     server: {
       open: true,

--- a/server/app.py
+++ b/server/app.py
@@ -5,6 +5,7 @@ from flask_cors import CORS
 
 from models import db, connect_db
 from main import scrape_mynintendo, message_discord, delete_old_records, check_items, get_changes
+from errors import CustomError
 
 import dotenv
 dotenv.load_dotenv()
@@ -53,9 +54,12 @@ def call_scrape_fn():
 
 @app.get('/api/delete')
 def delete_records():
-    results = delete_old_records()
-
-    return f"Deleted {results} entries."
+    try:
+        results = delete_old_records()
+        return f"Deleted {results} entries."
+    except Exception as e:
+        print("api/delete error: ",str(e))
+        raise CustomError("An error occurred while deleting records.")
 
 
 @app.get("/api/get-items")
@@ -63,6 +67,38 @@ def call_check_items():
     items = check_items()
 
     return jsonify(items)
+
+
+@app.after_request
+def add_header(response):
+    """Add non-caching headers on every request."""
+
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+    response.cache_control.no_store = True
+    return response
+
+
+@app.errorhandler(404)
+def handle_not_found_error(error):
+    response = {
+        "message": "Resource not found.",
+    }
+    return jsonify(response), 404
+
+
+@app.errorhandler(Exception)
+def handle_error(error):
+    if isinstance(error, CustomError):
+        custom_error_message = error.message
+        response = {
+            "error": custom_error_message,
+        }
+    else:
+        response = {
+            "message": "An error occurred.",
+        }
+    
+    return jsonify(response), 500  
 
 
 with app.app_context():

--- a/server/errors.py
+++ b/server/errors.py
@@ -1,0 +1,15 @@
+class DatabaseError(Exception):
+    """Custom exception for database-related errors."""
+    def __init__(self, message, original_exception=None):
+        super().__init__(message)
+        self.original_exception = original_exception
+
+class CSSTagSelectorError(Exception):
+    """Custom exception for database-related errors."""
+    def __init__(self, message, original_exception=None):
+        super().__init__(message)
+        self.original_exception = original_exception
+
+class CustomError(Exception):
+    def __init__(self, message):
+        self.message = message

--- a/server/main.py
+++ b/server/main.py
@@ -29,7 +29,7 @@ def check_items():
     # Find items, based on the CSS tag BasicTilestyles__Info-sc
     items = soup.find_all(
         'div', class_=re.compile('BasicTilestyles__Info-sc'))
-
+    # print(items)
     if not items:
         raise CSSTagSelectorError("The CSS tag for items have changed.")
 

--- a/server/main.py
+++ b/server/main.py
@@ -18,10 +18,8 @@ url = "https://www.nintendo.com/store/exclusives/rewards/"
 def check_items():
     """ Function to scrape items listed on MyNintendo Rewards"""
 
-    headers = {'Cache-Control': 'no-cache, must-revalidate'}
-
     # get the text from the provided url
-    html_text = requests.get(url, headers=headers).text
+    html_text = requests.get(url).text
 
     soup = BeautifulSoup(html_text, 'lxml')
     item_costs = {}
@@ -122,7 +120,7 @@ def scrape_mynintendo():
     except SQLAlchemyError as e:
         db.session.rollback()
         print(str(e))
-        raise DatabaseError("Database error occurred while committing changes.")
+        raise DatabaseError("Database error occurred while updating database for changes.")
 
     if not changes:
         changes = "No changes."
@@ -175,7 +173,7 @@ def delete_old_records():
     except SQLAlchemyError as e:
         db.session.rollback()
         print(str(e))
-        raise DatabaseError("Database error occurred while committing changes.")
+        raise DatabaseError("Database error occurred while trying to delete records.")
 
     deleted = deleted_listings + deleted_changes
     return deleted

--- a/server/main.py
+++ b/server/main.py
@@ -18,8 +18,10 @@ url = "https://www.nintendo.com/store/exclusives/rewards/"
 def check_items():
     """ Function to scrape items listed on MyNintendo Rewards"""
 
+    headers = {'Cache-Control': 'no-cache, must-revalidate'}
+
     # get the text from the provided url
-    html_text = requests.get(url).text
+    html_text = requests.get(url, headers=headers).text
 
     soup = BeautifulSoup(html_text, 'lxml')
     item_costs = {}
@@ -120,7 +122,8 @@ def scrape_mynintendo():
     except SQLAlchemyError as e:
         db.session.rollback()
         print(str(e))
-        raise DatabaseError("Database error occurred while updating database for changes.")
+        raise DatabaseError(
+            "Database error occurred while updating database for changes.")
 
     if not changes:
         changes = "No changes."
@@ -173,7 +176,8 @@ def delete_old_records():
     except SQLAlchemyError as e:
         db.session.rollback()
         print(str(e))
-        raise DatabaseError("Database error occurred while trying to delete records.")
+        raise DatabaseError(
+            "Database error occurred while trying to delete records.")
 
     deleted = deleted_listings + deleted_changes
     return deleted

--- a/server/main.py
+++ b/server/main.py
@@ -45,7 +45,7 @@ def check_items():
                 'span')[2] if price_element else None
             price = price_span.text if price_span else "Price Not Found"
 
-        elif stock and stock.text == "Sold out":
+        elif stock and stock.text != "Exclusive":
             price = stock.text
         else:
             price = "Price Not Found"

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,7 @@ import requests
 from deepdiff import DeepDiff
 from models import db, Listings, Changes
 from datetime import datetime
+from sqlalchemy.exc import SQLAlchemyError
 import re
 
 import dotenv
@@ -111,7 +112,12 @@ def scrape_mynintendo():
     if changes:
         Changes.add_record(changes)
     new_item = Listings.add_record(results)
-    db.session.commit()  # wrap in a try/catch?
+
+    try:
+        db.session.commit()
+    except SQLAlchemyError:
+        db.session.rollback()
+        return {"error": "Database error occurred while committing changes."}
 
     if not changes:
         changes = "No changes."

--- a/server/tests.py
+++ b/server/tests.py
@@ -25,91 +25,98 @@ class TestCalculateExpDate(TestCase):
 
 class TestCheckItemsFunction(TestCase):
 
+    def setUp(self):
+        self.mock_response = Mock()
+        self.mock_response.text = """
+            <html>
+                <body>
+                    <div class="BasicTilestyles__Info-sc">
+                        <div>
+                            <h2>Item 1 (Sold out)</h2>
+                        </div>
+                        <div class="ProductTilestyles__DescriptionTag-sc">Sold out</div>
+                        <div class="ProductTilestyles__PriceWrapper-sc">
+                            <div class="Pricestyles__Price-sc">
+                                <div class="Pricestyles__Price-sc">
+                                    <span class="Pricestyles_MSRP">
+                                        <span class="ScreenReaderOnlystyles">Regular Price:</span>
+                                        <div class="Pricestyles_PlatinumPoints">
+                                            <div class="Imagestyles_ImageWrapper">
+                                                <img>
+                                            </div>
+                                            <span class="Pricestyles_PlatinumPointsText">
+                                                <span>Now: $10</span>
+                                            </span>
+                                        </div>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="BasicTilestyles__Info-sc">
+                        <div>
+                            <h2>Item 2 (Normal)</h2>
+                        </div>
+                        <div class="ProductTilestyles__DescriptionTag-sc">Exclusive</div>
+                        <div class="ProductTilestyles__PriceWrapper-sc">
+                            <div class="Pricestyles__Price-sc">
+                                <div class="Pricestyles__Price-sc">
+                                    <span class="Pricestyles_MSRP">
+                                        <span class="ScreenReaderOnlystyles">Regular Price:</span>
+                                        <div class="Pricestyles_PlatinumPoints">
+                                            <div class="Imagestyles_ImageWrapper">
+                                                <img>
+                                            </div>
+                                            <span class="Pricestyles_PlatinumPointsText">
+                                                <span>$15</span>
+                                            </span>
+                                        </div>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="BasicTilestyles__Info-sc">
+                        <div>
+                            <h2>Item 3 (CSS price tag changed)</h2>
+                        </div>
+                        <div class="ProductTilestyles__DescriptionTag-sc">Exclusive</div>
+                        <div class="ProductTilestyles__PriceWrapper-change">
+                            <div class="Pricestyles__Price-sc">
+                                <div class="Pricestyles__Price-sc">
+                                    <span class="Pricestyles_MSRP">
+                                        <span class="ScreenReaderOnlystyles">Regular Price:</span>
+                                        <div class="Pricestyles_PlatinumPoints">
+                                            <div class="Imagestyles_ImageWrapper">
+                                                <img>
+                                            </div>
+                                            <span class="Pricestyles_PlatinumPointsText">
+                                                <span>$15</span>
+                                            </span>
+                                        </div>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </body>
+            </html>
+        """
+
     @patch('requests.get')
     def test_check_items(self, mock_get):
-
-        mock_html_text = """
-            <div class="BasicTilestyles__Info-sc">
-                <div>
-                    <h2>Item 1</h2>
-                </div>
-                <div class="ProductTilestyles__DescriptionTag-sc">Exclusive</div>
-                <div class="ProductTilestyles__PriceWrapper-sc">
-                    <div class="Pricestyles__Price-sc">
-                        <div class="Pricestyles__Price-sc">
-                            <span class="Pricestyles_MSRP">
-                                <span class="ScreenReaderOnlystyles">Regular Price:</span>
-                                <div class="Pricestyles_PlatinumPoints">
-                                    <div class="Imagestyles_ImageWrapper">
-                                        <img>
-                                    </div>
-                                    <span class="Pricestyles_PlatinumPointsText">
-                                        <span>$10</span>
-                                    </span>
-                                </div>
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        """
-
-
-        mock_response = Mock()
-        mock_response.text = mock_html_text
-        mock_get.return_value = mock_response
+        mock_get.return_value = self.mock_response
 
         item_costs = check_items()
-        item_costs["Item 1"] = item_costs["Item 1"].strip()
-
-        self.assertEqual(item_costs, {'Item 1': '$10'})
-
+        item_costs['Item 2 (Normal)'] = item_costs['Item 2 (Normal)'].strip()
         
-    @patch('requests.get')    
-    def test_check_items_no_stock(self, mock_get):
-        # Mocked HTML content for testing
-        mock_html_text = """
-            <div class="BasicTilestyles__Info-sc">
-                <div>
-                    <h2>Item 1</h2>
-                </div>
-                <div class="ProductTilestyles__DescriptionTag-sc">Sold out</div>
-                <div class="ProductTilestyles__PriceWrapper-sc">
-                    <div class="Pricestyles__Price-sc">
-                        <div class="Pricestyles__Price-sc">
-                            <span class="Pricestyles_MSRP">
-                                <span class="ScreenReaderOnlystyles">Regular Price:</span>
-                                <div class="Pricestyles_PlatinumPoints">
-                                    <div class="Imagestyles_ImageWrapper">
-                                        <img>
-                                    </div>
-                                    <span class="Pricestyles_PlatinumPointsText">
-                                        <span>$10</span>
-                                    </span>
-                                </div>
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        """
 
-        mock_response = Mock()
-        mock_response.text = mock_html_text
-        mock_get.return_value = mock_response
-
-        expected_result = {
-            "Item 1": "Sold out"
-        }
-
-        result = check_items()
-        self.assertEqual(result, expected_result)
+        self.assertEqual(item_costs, {'Item 1 (Sold out)': 'Sold out', 'Item 2 (Normal)': '$15', 'Item 3 (CSS price tag changed)': 'Price Not Found'})
 
     @patch('requests.get')
     def test_check_items_css_error(self, mock_get):
-        mock_response = Mock()
-        mock_response.text = "<html></html>"
-        mock_get.return_value = mock_response
+        self.mock_response.text = "<html></html>"  # Simulate no items found
+        mock_get.return_value = self.mock_response
 
         with self.assertRaises(CSSTagSelectorError):
             check_items()

--- a/server/tests.py
+++ b/server/tests.py
@@ -109,9 +109,9 @@ class TestCheckItemsFunction(TestCase):
 
         item_costs = check_items()
         item_costs['Item 2 (Normal)'] = item_costs['Item 2 (Normal)'].strip()
-        
 
-        self.assertEqual(item_costs, {'Item 1 (Sold out)': 'Sold out', 'Item 2 (Normal)': '$15', 'Item 3 (CSS price tag changed)': 'Price Not Found'})
+        self.assertEqual(item_costs, {'Item 1 (Sold out)': 'Sold out',
+                         'Item 2 (Normal)': '$15', 'Item 3 (CSS price tag changed)': 'Price Not Found'})
 
     @patch('requests.get')
     def test_check_items_css_error(self, mock_get):


### PR DESCRIPTION
Fixes #36 

Previously, `check_items` would cause the server to crash if the CSS tags were changed and broke the rest of the code that depended on the scraped results to exist. With this PR, the functions are updated to better handle situations when the My Nintendo Rewards website updates with breaking changes. In addition, error handling was added to the database modification transactions incase there is an issue with those functions. 