### PR TITLE
Update CSS selector used for stock label

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -37,8 +37,10 @@ def check_items():
         # the website changes what header is used (e.g. h2, h3) so need a non hard coded way to target it via find_next()
         header = item.div.find_next()
         name = header.text.strip() if header else "Unknown Name"
+        # targets the element that displays "Exclusive" or "Sold out" label to help determine stock status
+        # Use of __DescriptionTag-sc is to reduce the amount of hard coding for the CSS class selection due to website changing what they use
         stock = item.find(
-            'div', class_=re.compile('ProductTilestyles__DescriptionTag-sc'))  # checks if the item has "Out of Stock" label
+            'div', class_=re.compile('__DescriptionTag-sc'))
 
         if stock and stock.text == "Exclusive":
             price_element = item.find('div', class_=re.compile(

--- a/server/main.py
+++ b/server/main.py
@@ -42,6 +42,9 @@ def check_items():
         stock = item.find(
             'div', class_=re.compile('__DescriptionTag-sc'))
 
+        if not stock:
+            raise CSSTagSelectorError("The CSS tag for stock has changed.")
+
         if stock and stock.text == "Exclusive":
             price_element = item.find('div', class_=re.compile(
                 'ProductTilestyles__PriceWrapper-sc'))


### PR DESCRIPTION
The MyNintendo rewards page updated the CSS class used for their "Exclusive" and "Sold out" label, which prevented the previous code from properly determining an item's stock status. Originally I updated the CSS class being selected from `ProductTilestyles__DescriptionTag-sc` to `DescriptionTagstyles__DescriptionTag-sc`, however this runs the risk of a similar website change breaking my webscraping. Thus, I opted to use the more generic selector of `__DescriptionTag-sc` assuming this piece will stay consistent across multiple website changes. 

Additionally, to allow for a more accurate response on what happened when the CSS class changes for the targeted label, an error is raised when `None` is returned from the label scraped. 