### PR TITLE
Use checkout version 4

### DIFF
--- a/.github/workflows/fly.io-merge.yml
+++ b/.github/workflows/fly.io-merge.yml
@@ -12,6 +12,6 @@ jobs:
     name: Deploy app
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: cd server/ && flyctl deploy --remote-only


### PR DESCRIPTION
Resolve the Github Action warning regarding using actions that still use Node v16.