### PR TITLE
Update Theme Icon

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
+        "@fortawesome/fontawesome-svg-core": "^6.5.1",
+        "@fortawesome/free-solid-svg-icons": "^6.5.1",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -17,6 +20,7 @@
         "@types/node": "^16.18.12",
         "@types/react": "^18.0.27",
         "@types/react-dom": "^18.0.10",
+        "@types/react-fontawesome": "^1.6.8",
         "@vitejs/plugin-react": "^4.0.4",
         "axios": "^1.6.0",
         "react": "^18.2.0",
@@ -912,6 +916,51 @@
         "node": ">=12"
       }
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1282,6 +1331,14 @@
       "version": "18.0.10",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
       "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-fontawesome": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@types/react-fontawesome/-/react-fontawesome-1.6.8.tgz",
+      "integrity": "sha512-+dQ+4jccHraCd/FI4uSeY/O7c1RZ+wVASTgpCgbC6ijh1zSDsr0cb9XU3Dbfy5eJPyXq5QPp9W9RJTVRf+5+pA==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -2989,7 +3046,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3341,6 +3397,21 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -4966,6 +5037,35 @@
       "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
       "optional": true
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-S1PPfU3mIJa59biTtXJz1oI0+KAXW6bkAb31XKhxdxtuXDiUIFsih4JR1v5BbxY7hVHsD1RKq+jRkVRaf773NQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
+    },
     "@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -5245,6 +5345,14 @@
       "version": "18.0.10",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
       "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-fontawesome": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@types/react-fontawesome/-/react-fontawesome-1.6.8.tgz",
+      "integrity": "sha512-+dQ+4jccHraCd/FI4uSeY/O7c1RZ+wVASTgpCgbC6ijh1zSDsr0cb9XU3Dbfy5eJPyXq5QPp9W9RJTVRf+5+pA==",
       "requires": {
         "@types/react": "*"
       }
@@ -6445,8 +6553,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-hash": {
       "version": "3.0.0",
@@ -6653,6 +6760,23 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+        }
+      }
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },

--- a/app/package.json
+++ b/app/package.json
@@ -5,6 +5,9 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -12,6 +15,7 @@
     "@types/node": "^16.18.12",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "@types/react-fontawesome": "^1.6.8",
     "@vitejs/plugin-react": "^4.0.4",
     "axios": "^1.6.0",
     "react": "^18.2.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,7 +4,7 @@ import ThemeSwitcher from "./components/ThemeSwitcher";
 function App() {
   return (
     <div className="flex flex-col items-center p-4 bg-white dark:bg-slate-800">
-      <div className="w-full flex flex-row-reverse ">
+      <div className="w-full flex flex-row-reverse sm:absolute right-5 top-5">
         <ThemeSwitcher />
       </div>
       <Items />

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,8 +3,8 @@ import ThemeSwitcher from "./components/ThemeSwitcher";
 
 function App() {
   return (
-    <div className="flex flex-col items-center p-4 bg-white dark:bg-slate-800 min-h-screen">
-      <div className="w-full flex flex-row-reverse sm:absolute sm:w-min right-5 top-5">
+    <div className="flex flex-col items-center p-4 dark:bg-slate-800 min-h-screen">
+      <div className="w-full flex flex-row-reverse sm:absolute sm:w-min right-5 top-5" >
         <ThemeSwitcher />
       </div>
       <Items />

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -3,8 +3,8 @@ import ThemeSwitcher from "./components/ThemeSwitcher";
 
 function App() {
   return (
-    <div className="flex flex-col items-center p-4 bg-white dark:bg-slate-800">
-      <div className="w-full flex flex-row-reverse sm:absolute right-5 top-5">
+    <div className="flex flex-col items-center p-4 bg-white dark:bg-slate-800 min-h-screen">
+      <div className="w-full flex flex-row-reverse sm:absolute sm:w-min right-5 top-5">
         <ThemeSwitcher />
       </div>
       <Items />

--- a/app/src/components/Changes.tsx
+++ b/app/src/components/Changes.tsx
@@ -9,7 +9,7 @@ interface ChangesProps {
 export default function Changes({ recentChange, lastChange }: ChangesProps) {
   return (
     <div className="flex gap-x-3 mb-3">
-      <div className="flex-1 bg-white rounded-md p-2 dark:bg-slate-800 ">
+      <div className="flex-1 rounded-md p-2 dark:bg-slate-800 ">
         <p className="dark:text-slate-300">Latest Scrape Results:</p>
         {typeof recentChange.items === "string" ? (
           <p className="font-bold text-lg dark:text-slate-300"> {recentChange.items}</p>
@@ -17,7 +17,7 @@ export default function Changes({ recentChange, lastChange }: ChangesProps) {
           <ChangedItemsList changedItemsData={recentChange.items} />
         )}
       </div>
-      <div className="flex-1 bg-white rounded-md p-2 dark:bg-slate-800 ">
+      <div className="flex-1 rounded-md p-2 dark:bg-slate-800 ">
         <p className="dark:text-slate-300">Last Change:</p>
 
         <ChangedItemsList changedItemsData={lastChange.items} />

--- a/app/src/components/ItemCard.tsx
+++ b/app/src/components/ItemCard.tsx
@@ -8,7 +8,7 @@ export function ItemCard({ item, index, cost }: ItemCardProps) {
   return (
     <div
       key={`${item}-${index}`}
-      className="w-full h-full flex flex-col shadow-lg p-4 bg-white dark:bg-slate-800 rounded-lg justify-between"
+      className="w-full h-full flex flex-col shadow-lg p-4 dark:bg-slate-800 rounded-lg justify-between"
     >
       {/* <img src="https://placehold.co/300" /> */}
       <p className="mb-auto text-lg tracking-tight text-black dark:text-slate-200 ">

--- a/app/src/components/ThemeSwitcher.tsx
+++ b/app/src/components/ThemeSwitcher.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {faSun, faMoon} from "@fortawesome/free-solid-svg-icons";
 
 const ThemeSwitcher = () => {
   const [darkMode, setDarkMode] = useState(false);
@@ -22,7 +24,7 @@ const ThemeSwitcher = () => {
       onClick={toggleDarkMode}
       className="px-4 py-2 rounded-md bg-slate-800 dark:bg-white text-white dark:text-black"
     >
-      {darkMode ? "Light Mode" : "Dark Mode"}
+      {darkMode ? <FontAwesomeIcon icon={faSun} /> : <FontAwesomeIcon icon={faMoon} />}
     </button>
   );
 };

--- a/app/src/components/ThemeSwitcher.tsx
+++ b/app/src/components/ThemeSwitcher.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {faSun, faMoon} from "@fortawesome/free-solid-svg-icons";
 
 const ThemeSwitcher = () => {
-  const [darkMode, setDarkMode] = useState(false);
+  const [darkMode, setDarkMode] = useState(true);
 
   useEffect(() => {
     const isDarkMode = localStorage.getItem("darkMode") === "true";

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -2,16 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  overflow: auto;
+  scrollbar-gutter: stable both-edges;
+  
+}
+
+html.dark {
+  background-color: rgb(30 41 59);
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }


### PR DESCRIPTION
Update the theme switching button to use icons instead of text to represent night mode:

<img width="78" alt="image" src="https://github.com/samau3/mynintendo-scraper/assets/69769431/d72da6fd-c945-4e21-b5fc-dc344c55e9b3">

In addition, utilized `scrollbar-gutter` to prevent layout shift once the scraped data is loaded and a scrollbar is added. 