### PR TITLE
Simplify Route Responses

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -65,6 +65,9 @@ def call_check_items():
 
     return jsonify(items)
 
+@app.get("/api/check")
+def check_api():
+    return jsonify("API is running.")
 
 @app.errorhandler(404)
 def handle_not_found_error(error):

--- a/server/app.py
+++ b/server/app.py
@@ -49,7 +49,7 @@ def call_scrape_fn():
     if results["items"] != "No changes.":
         message_discord(results["items"])
 
-    return f"Scraped at {results['timestamp']}."
+    return jsonify(results["timestamp"])
 
 
 @app.get('/api/delete')

--- a/server/app.py
+++ b/server/app.py
@@ -49,7 +49,7 @@ def call_scrape_fn():
     if results["items"] != "No changes.":
         message_discord(results["items"])
 
-    return results
+    return f"Scraped at {results['timestamp']}."
 
 
 @app.get('/api/delete')


### PR DESCRIPTION
For the cron job service used to automate the web scraping, they prefer smaller data transfers during the request. Thus to minimize the cron job failing, the response returned from the cron job route is simplified to just the timestamp. 

In addition, a new route is created to act as a health check for a status page. 