### PR TITLE
Fix value changed bug

### DIFF
--- a/server/helpers/remove_trademark_false_positives.py
+++ b/server/helpers/remove_trademark_false_positives.py
@@ -34,7 +34,7 @@ def remove_trademark_false_positives(differences_dictionary):
 
     # Find indices of common strings between added and removed items
     added_indices, removed_indices = index_of_common_strings(
-        cleaned_dict["dictionary_item_added"], cleaned_dict["dictionary_item_removed"])
+        cleaned_dict.get("dictionary_item_added", []), cleaned_dict.get("dictionary_item_removed", []))
     
     # If no indices are found for either added or removed items, return the original dictionary
     if not added_indices or not removed_indices:

--- a/server/main.py
+++ b/server/main.py
@@ -78,7 +78,7 @@ def check_for_changes(last_stored_items, scraped_items):
 
     changes = {}
     for difference in cleaned_diff:
-
+        print(difference)
         # if difference is added
         if difference == "dictionary_item_added":
             new_items = []

--- a/server/main.py
+++ b/server/main.py
@@ -32,7 +32,7 @@ def check_items():
     # Find items, based on the CSS tag BasicTilestyles__Info-sc
     items = soup.find_all(
         'div', class_=re.compile('sc-1bsju6x-4'))
-    # print(items)
+
     if not items:
         raise CSSTagSelectorError("The CSS tag for items have changed.")
 
@@ -67,25 +67,25 @@ def check_for_changes(last_stored_items, scraped_items):
         returning the resulting differences"""
 
     diff = DeepDiff(last_stored_items, scraped_items)
-    print("diff", diff)
+
     if (len(diff) == 0):
         return None
 
     cleaned_diff = remove_trademark_false_positives(diff)
-    print("cleaned_diff", cleaned_diff)
+
     if (len(cleaned_diff) == 0):
         return None
 
     changes = {}
     for difference in cleaned_diff:
-        print(difference)
+
         # if difference is added
         if difference == "dictionary_item_added":
             new_items = []
             for item in diff[difference]:
                 new_items.append({item[6:-2]: scraped_items[item[6:-2]]})
             changes["New Items"] = new_items
-        print(diff[difference])
+
         # if difference is removed
         if difference == "dictionary_item_removed":
             removed_items = []
@@ -122,13 +122,13 @@ def scrape_mynintendo():
     results = check_items()
     last_record = Listings.query.order_by(Listings.id.desc()).first()
     last_items = last_record.items if last_record is not None else {}
-    print("got results and last items")
+
     changes = check_for_changes(last_items, results)
-    print("checked for changes")
+
     if changes:
         Changes.add_record(changes)
     new_item = Listings.add_record(results)
-    print("added record")
+
     try:
         db.session.commit()
     except SQLAlchemyError as e:
@@ -138,12 +138,12 @@ def scrape_mynintendo():
             "Database error occurred while updating database for changes.")
     except Exception as e:
         print(str(e))
-        raise CustomError(e, "Error occurred while updating database for changes.")
+        raise CustomError(
+            e, "Error occurred while updating database for changes.")
 
-    print("committed to db")
     if not changes:
         changes = "No changes."
-    print("returning changes")
+
     return {"items": changes, "timestamp": new_item.timestamp}
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -67,12 +67,12 @@ def check_for_changes(last_stored_items, scraped_items):
         returning the resulting differences"""
 
     diff = DeepDiff(last_stored_items, scraped_items)
-
+    print("diff", diff)
     if (len(diff) == 0):
         return None
 
     cleaned_diff = remove_trademark_false_positives(diff)
-
+    print("cleaned_diff", cleaned_diff)
     if (len(cleaned_diff) == 0):
         return None
 

--- a/server/main.py
+++ b/server/main.py
@@ -85,7 +85,7 @@ def check_for_changes(last_stored_items, scraped_items):
             for item in diff[difference]:
                 new_items.append({item[6:-2]: scraped_items[item[6:-2]]})
             changes["New Items"] = new_items
-
+        print(diff[difference])
         # if difference is removed
         if difference == "dictionary_item_removed":
             removed_items = []

--- a/server/tests.py
+++ b/server/tests.py
@@ -104,6 +104,13 @@ class TestRemoveTrademarkFalsePositives(TestCase):
         result = remove_trademark_false_positives(differences)
         self.assertEqual(result, differences)
 
+    def test_remove_trademark_false_positives_values_changed(self):
+        differences = {
+            "values_changed": {'root[2]': {'new_value': 4, 'old_value': 2}}
+        }
+        result = remove_trademark_false_positives(differences)
+        self.assertEqual(result, differences)
+
 
 class TestCheckItemsFunction(TestCase):
 


### PR DESCRIPTION
The function `remove_trademark_false_positives` should only be ran when the difference dictionary has the keys `dictionary_item_added` and `dictionary_item_removed`. The previous code had that logic in place, however it did not properly handle accessing those keys if they did not exist as it used bracket notation to access the keys (similar to how it would have been done in JS) which led to a key access error. The solution was to utilize `.get()` to prevent accessing a non existent key without a proper fallback. 