### PR TITLE
Add Image Scraping of Items

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -30,7 +30,7 @@ def show_home_page():
     raw_item_elements = load_items()
     items = get_items(raw_item_elements)
     images = get_item_images(raw_item_elements)
-    scrape_results = scrape_mynintendo(raw_item_elements)
+    scrape_results = scrape_mynintendo(items)
     last_change = get_changes()
 
     if scrape_results["items"] != "No changes.":
@@ -48,7 +48,8 @@ def show_home_page():
 @app.get('/api/scrape')
 def call_scrape_fn():
     raw_item_elements = load_items()
-    results = scrape_mynintendo(raw_item_elements)
+    items = get_items(raw_item_elements)
+    results = scrape_mynintendo(items)
 
     if results["items"] != "No changes.":
         message_discord(results["items"])

--- a/server/app.py
+++ b/server/app.py
@@ -4,7 +4,7 @@ from flask import Flask, jsonify
 from flask_cors import CORS
 
 from models import db, connect_db
-from main import scrape_mynintendo, message_discord, delete_old_records, check_items, get_changes, load_page_data
+from main import scrape_mynintendo, message_discord, delete_old_records, check_items, get_changes, load_page_data, get_item_images
 from errors import CustomError, CSSTagSelectorError
 
 import dotenv
@@ -65,8 +65,9 @@ def delete_records():
 def call_check_items():
     page_data = load_page_data()
     items = check_items(page_data)
+    # print(get_item_images(page_data))
 
-    return jsonify(items)
+    return jsonify({"items": items, "images": get_item_images(page_data)})
 
 
 @app.get("/api/check-fly")

--- a/server/helpers/find_items.py
+++ b/server/helpers/find_items.py
@@ -1,0 +1,12 @@
+import re
+from errors import CSSTagSelectorError
+
+
+def find_items(soup, tag):
+    """ Function to scrape items listed on MyNintendo Rewards"""
+    items = soup.find_all('a', class_=re.compile(tag))
+
+    if not items:
+        raise CSSTagSelectorError("The CSS tag for items have changed.")
+
+    return items

--- a/server/main.py
+++ b/server/main.py
@@ -18,6 +18,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from webdriver_manager.chrome import ChromeDriverManager
 
 from helpers.remove_trademark_false_positives import remove_trademark_false_positives
+from helpers.find_items import find_items
 
 import dotenv
 dotenv.load_dotenv()
@@ -52,15 +53,11 @@ def check_items(page_data=None):
     item_costs = {}
 
     # Find items, based on the CSS tag used
-    items = soup.find_all(
-        'a', class_=re.compile(ITEMS_CSS_TAG))
-
-    if not items:
-        raise CSSTagSelectorError("The CSS tag for items have changed.")
+    items = find_items(soup, ITEMS_CSS_TAG)
 
     for item in items:
         name = item.get('aria-label', 'Unknown Name').strip()
-        
+
         # targets the element that displays "Exclusive" or "Sold out" label to help determine stock status
         # Use of __DescriptionTag-sc is to reduce the amount of hard coding for the CSS class selection due to website changing what they use
         stock = item.find(
@@ -88,9 +85,7 @@ def get_item_images(page_data=None):
     soup = BeautifulSoup(page_data, 'lxml')
     item_images = {}
 
-    items = soup.find_all('a', class_=re.compile('sc-1bsju6x-1'))
-    if not items:
-        raise CSSTagSelectorError("The CSS tag for item cards have changed.")
+    items = find_items(soup, ITEMS_CSS_TAG)
 
     for item in items:
 
@@ -99,11 +94,11 @@ def get_item_images(page_data=None):
         # targets the element that displays "Exclusive" or "Sold out" label to help determine stock status
         # Use of __DescriptionTag-sc is to reduce the amount of hard coding for the CSS class selection due to website changing what they use
         image = item.find(
-            'img', class_=re.compile('sc-1244ond-1 eaPLXy'))
+            'img', class_=re.compile('sc-1244ond-1'))
 
         if not image:
             raise CSSTagSelectorError("The CSS tag for images has changed.")
-        
+
         image_url = image.get('src', 'https://placehold.co/600x400')
 
         item_images[name] = image_url

--- a/server/main.py
+++ b/server/main.py
@@ -155,17 +155,16 @@ def get_changes():
     return last_change
 
 
-def scrape_mynintendo(items=None):
+def scrape_mynintendo(current_items):
     """ Function that calls scraping function and updates database if changes were found"""
-    results = get_items(items)
     last_record = Listings.query.order_by(Listings.id.desc()).first()
     last_items = last_record.items if last_record is not None else {}
 
-    changes = check_for_changes(last_items, results)
+    changes = check_for_changes(last_items, current_items)
 
     if changes:
         Changes.add_record(changes)
-    new_item = Listings.add_record(results)
+    new_item = Listings.add_record(current_items)
 
     try:
         db.session.commit()

--- a/server/main.py
+++ b/server/main.py
@@ -84,6 +84,35 @@ def check_items(page_data=None):
     return item_costs
 
 
+def get_item_images(page_data=None):
+    """ Function to scrape items listed on MyNintendo Rewards"""
+
+    soup = BeautifulSoup(page_data, 'lxml')
+    item_images = {}
+
+    items = soup.find_all('a', class_=re.compile('sc-1bsju6x-1'))
+    if not items:
+        raise CSSTagSelectorError("The CSS tag for item cards have changed.")
+
+    for item in items:
+
+        name = item.get('aria-label', 'Unknown Name').strip()
+
+        # targets the element that displays "Exclusive" or "Sold out" label to help determine stock status
+        # Use of __DescriptionTag-sc is to reduce the amount of hard coding for the CSS class selection due to website changing what they use
+        image = item.find(
+            'img', class_=re.compile('sc-1244ond-1 eaPLXy'))
+
+        if not image:
+            raise CSSTagSelectorError("The CSS tag for images has changed.")
+        
+        image_url = image.get('src', 'https://placehold.co/600x400')
+
+        item_images[name] = image_url
+
+    return item_images
+
+
 def check_for_changes(last_stored_items, scraped_items):
     """ Function to compare two dictionaries, 
         returning the resulting differences"""

--- a/server/main.py
+++ b/server/main.py
@@ -24,7 +24,7 @@ dotenv.load_dotenv()
 
 
 MYNINTENDO_URL = "https://www.nintendo.com/store/exclusives/rewards/"
-ITEMS_CSS_TAG = "sc-1bsju6x-4"
+ITEMS_CSS_TAG = "sc-1bsju6x-1"
 
 
 options = webdriver.ChromeOptions()
@@ -53,16 +53,14 @@ def check_items(page_data=None):
 
     # Find items, based on the CSS tag used
     items = soup.find_all(
-        'div', class_=re.compile(ITEMS_CSS_TAG))
+        'a', class_=re.compile(ITEMS_CSS_TAG))
 
     if not items:
         raise CSSTagSelectorError("The CSS tag for items have changed.")
 
     for item in items:
-        # the website changes what header is used (e.g. h2, h3) so need a non hard coded way to target it via find_next()
-        header = item.div.find_next()
-        name = header.text.strip() if header else "Unknown Name"
-
+        name = item.get('aria-label', 'Unknown Name').strip()
+        
         # targets the element that displays "Exclusive" or "Sold out" label to help determine stock status
         # Use of __DescriptionTag-sc is to reduce the amount of hard coding for the CSS class selection due to website changing what they use
         stock = item.find(

--- a/server/tests.py
+++ b/server/tests.py
@@ -2,12 +2,15 @@ from unittest import TestCase, main
 from unittest.mock import Mock
 from datetime import datetime, timedelta
 
-from main import check_items
+from bs4 import BeautifulSoup
+
+from main import get_items
 from errors import CSSTagSelectorError
 from helpers.calculate_expiration_date import calculate_expiration_date, DateTimeProvider
 from helpers.remove_trademark_false_positives import remove_trademark_false_positives
 from helpers.index_of_common_strings import index_of_common_strings
 from helpers.remove_trademark_symbols import remove_trademark_symbols
+from helpers.find_items import find_items
 
 
 class TestCalculateExpDate(TestCase):
@@ -112,180 +115,192 @@ class TestRemoveTrademarkFalsePositives(TestCase):
         self.assertEqual(result, differences)
 
 
+class TestFindItemsFunction(TestCase):
+    def test_get_items_css_error(self):
+        self.mock_response = "<html></html>"  # Simulate no items found
+
+        with self.assertRaises(CSSTagSelectorError) as cm:
+            self.items = find_items(BeautifulSoup(
+                self.mock_response, 'lxml'), "sc-1bsju6x-1")
+        exception_message = str(cm.exception)
+        self.assertEqual(
+            exception_message, "The CSS tag for items have changed.")
+
+
 class TestCheckItemsFunction(TestCase):
-    def setUp(self):
+    def test_get_items(self):
         self.mock_response = """
             <html>
                 <body>
-                    <div class="sc-1bsju6x-4 eJevZe">
-                        <div class="sc-1bsju6x-6 irzLJU">
-                            <div class="sc-eg7slj-1 ieWZCg" style="color: rgb(72, 72, 72);">
-                                <h2 class="sc-s17bth-0 bMmuUN sc-w55g5t-0 gSthvS sc-eg7slj-2 iiGOlC">Item 1 (Normal)</h2>
-                                <div class="sc-m1loqs-5 bvcBeK"></div>
-                            </div>
-                            <div class="sc-tb903t-0 hwFxtm sc-m1loqs-4 gXVfCV">Exclusive</div>
-                            <div class="sc-m1loqs-3 gGJMHZ">
-                                <div class="sc-1f0n8u6-0 kNfSFq">
-                                    <div class="sc-1f0n8u6-1 icpwvf">
-                                        <span class="sc-1f0n8u6-5 fpvyxr">
-                                            <span class="sc-1gv8hi6-0 lktkyu sc-1f0n8u6-2 bFvx">Regular Price:</span>
-                                            <div data-testid="platinumPoints" class="sc-1f0n8u6-8 ftpArF">
-                                                <div class="sc-1244ond-0 bYKqUR sc-1yh2edi-0 GtTvR sc-1f0n8u6-7 gcszdM">
-                                                    <img alt="" loading="lazy" fetchpriority="low" class="sc-1244ond-1 eaPLXy" src="IMAGE_URL">
+                    <a aria-label="Item 1 (Normal)" class="sc-1bsju6x-1">
+                        <div class="sc-1bsju6x-4 eJevZe">
+                            <div class="sc-1bsju6x-6 irzLJU">
+                                <div class="sc-eg7slj-1 ieWZCg" style="color: rgb(72, 72, 72);">
+                                    <h2 class="sc-s17bth-0 bMmuUN sc-w55g5t-0 gSthvS sc-eg7slj-2 iiGOlC">Item 1 (Normal)</h2>
+                                    <div class="sc-m1loqs-5 bvcBeK"></div>
+                                </div>
+                                <div class="sc-tb903t-0 hwFxtm sc-m1loqs-4 gXVfCV">Exclusive</div>
+                                <div class="sc-m1loqs-3 gGJMHZ">
+                                    <div class="sc-1f0n8u6-0 kNfSFq">
+                                        <div class="sc-1f0n8u6-1 icpwvf">
+                                            <span class="sc-1f0n8u6-5 fpvyxr">
+                                                <span class="sc-1gv8hi6-0 lktkyu sc-1f0n8u6-2 bFvx">Regular Price:</span>
+                                                <div data-testid="platinumPoints" class="sc-1f0n8u6-8 ftpArF">
+                                                    <div class="sc-1244ond-0 bYKqUR sc-1yh2edi-0 GtTvR sc-1f0n8u6-7 gcszdM">
+                                                        <img alt="" loading="lazy" fetchpriority="low" class="sc-1244ond-1 eaPLXy" src="IMAGE_URL">
+                                                    </div>
+                                                    <span class="sc-1f0n8u6-10 imlIYl">
+                                                        <span class="sc-1f0n8u6-9 unbAu">800</span> Platinum Points
+                                                    </span>
                                                 </div>
-                                                <span class="sc-1f0n8u6-10 imlIYl">
-                                                    <span class="sc-1f0n8u6-9 unbAu">800</span> Platinum Points
-                                                </span>
-                                            </div>
-                                        </span>
+                                            </span>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="sc-eg7slj-0 cstaaz">
-                                <div class="sc-v8r1lj-1 UbrcP">
-                                    <div class="sc-v8r1lj-0 dQBnrT"></div>
-                                    <span>Exclusives</span>
+                                <div class="sc-eg7slj-0 cstaaz">
+                                    <div class="sc-v8r1lj-1 UbrcP">
+                                        <div class="sc-v8r1lj-0 dQBnrT"></div>
+                                        <span>Exclusives</span>
+                                    </div>
+                                    <button class="sc-1ud0cp0-0 jhpscK sc-m1loqs-0 jgyRXQ" title="Add to Wish List" aria-label="Add to Wish List" aria-pressed="false">
+                                        <svg viewBox="0 0 54 54" fill="currentColor" stroke="currentColor" width="24" role="presentation" alt="" data-testid="heartspark" color="currentColor" size="24">
+                                            <g class="hearts">
+                                                <path ></path>
+                                                <path ></path>
+                                            </g>
+                                            <g class="sparks">
+                                                <path ></path>
+                                                <path ></path>
+                                            <path ></path>
+                                            <path ></path>
+                                            </g>
+                                        </svg>
+                                    </button>
                                 </div>
-                                <button class="sc-1ud0cp0-0 jhpscK sc-m1loqs-0 jgyRXQ" title="Add to Wish List" aria-label="Add to Wish List" aria-pressed="false">
-                                    <svg viewBox="0 0 54 54" fill="currentColor" stroke="currentColor" width="24" role="presentation" alt="" data-testid="heartspark" color="currentColor" size="24">
-                                        <g class="hearts">
-                                            <path ></path>
-                                            <path ></path>
-                                        </g>
-                                        <g class="sparks">
-                                            <path ></path>
-                                            <path ></path>
-                                        <path ></path>
-                                        <path ></path>
-                                        </g>
-                                    </svg>
-                                </button>
                             </div>
                         </div>
-                    </div>
-                    <div class="sc-1bsju6x-4 eJevZe">
-                        <div class="sc-1bsju6x-6 irzLJU">
-                            <div class="sc-eg7slj-1 ieWZCg" style="color: rgb(72, 72, 72);">
-                                <h2 class="sc-s17bth-0 bMmuUN sc-w55g5t-0 gSthvS sc-eg7slj-2 iiGOlC">Item 2 (Sold Out)</h2>
-                                <div class="sc-m1loqs-5 bvcBeK"></div>
-                            </div>
-                            <div class="sc-tb903t-0 hwFxtm sc-m1loqs-4 gXVfCV">Sold Out</div>
-                            <div class="sc-m1loqs-3 gGJMHZ">
-                                <div class="sc-1f0n8u6-0 kNfSFq">
-                                    <div class="sc-1f0n8u6-1 icpwvf">
-                                        <span class="sc-1f0n8u6-5 fpvyxr">
-                                            <span class="sc-1gv8hi6-0 lktkyu sc-1f0n8u6-2 bFvx">Regular Price:</span>
-                                            <div data-testid="platinumPoints" class="sc-1f0n8u6-8 ftpArF">
-                                                <div class="sc-1244ond-0 bYKqUR sc-1yh2edi-0 GtTvR sc-1f0n8u6-7 gcszdM">
-                                                    <img alt="" loading="lazy" fetchpriority="low" class="sc-1244ond-1 eaPLXy" src="IMAGE_URL">
+                    </a>
+                    <a aria-label="Item 2 (Sold Out)" class="sc-1bsju6x-1">
+                        <div class="sc-1bsju6x-4 eJevZe">
+                            <div class="sc-1bsju6x-6 irzLJU">
+                                <div class="sc-eg7slj-1 ieWZCg" style="color: rgb(72, 72, 72);">
+                                    <h2 class="sc-s17bth-0 bMmuUN sc-w55g5t-0 gSthvS sc-eg7slj-2 iiGOlC">Item 2 (Sold Out)</h2>
+                                    <div class="sc-m1loqs-5 bvcBeK"></div>
+                                </div>
+                                <div class="sc-tb903t-0 hwFxtm sc-m1loqs-4 gXVfCV">Sold Out</div>
+                                <div class="sc-m1loqs-3 gGJMHZ">
+                                    <div class="sc-1f0n8u6-0 kNfSFq">
+                                        <div class="sc-1f0n8u6-1 icpwvf">
+                                            <span class="sc-1f0n8u6-5 fpvyxr">
+                                                <span class="sc-1gv8hi6-0 lktkyu sc-1f0n8u6-2 bFvx">Regular Price:</span>
+                                                <div data-testid="platinumPoints" class="sc-1f0n8u6-8 ftpArF">
+                                                    <div class="sc-1244ond-0 bYKqUR sc-1yh2edi-0 GtTvR sc-1f0n8u6-7 gcszdM">
+                                                        <img alt="" loading="lazy" fetchpriority="low" class="sc-1244ond-1 eaPLXy" src="IMAGE_URL">
+                                                    </div>
+                                                    <span class="sc-1f0n8u6-10 imlIYl">
+                                                        <span class="sc-1f0n8u6-9 unbAu">800</span>
+                                                        <!-- -->Platinum Points
+                                                    </span>
                                                 </div>
-                                                <span class="sc-1f0n8u6-10 imlIYl">
-                                                    <span class="sc-1f0n8u6-9 unbAu">800</span>
-                                                    <!-- -->Platinum Points
-                                                </span>
-                                            </div>
-                                        </span>
+                                            </span>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="sc-eg7slj-0 cstaaz">
-                                <div class="sc-v8r1lj-1 UbrcP">
-                                    <div class="sc-v8r1lj-0 dQBnrT"></div>
-                                    <span>Exclusives</span>
+                                <div class="sc-eg7slj-0 cstaaz">
+                                    <div class="sc-v8r1lj-1 UbrcP">
+                                        <div class="sc-v8r1lj-0 dQBnrT"></div>
+                                        <span>Exclusives</span>
+                                    </div>
+                                    <button class="sc-1ud0cp0-0 jhpscK sc-m1loqs-0 jgyRXQ" title="Add to Wish List" aria-label="Add to Wish List" aria-pressed="false">
+                                        <svg viewBox="0 0 54 54" fill="currentColor" stroke="currentColor" width="24" role="presentation" alt="" data-testid="heartspark" color="currentColor" size="24">
+                                            <g class="hearts">
+                                                <path ></path>
+                                                <path ></path>
+                                            </g>
+                                            <g class="sparks">
+                                                <path ></path>
+                                                <path ></path>
+                                            <path ></path>
+                                            <path ></path>
+                                            </g>
+                                        </svg>
+                                    </button>
                                 </div>
-                                <button class="sc-1ud0cp0-0 jhpscK sc-m1loqs-0 jgyRXQ" title="Add to Wish List" aria-label="Add to Wish List" aria-pressed="false">
-                                    <svg viewBox="0 0 54 54" fill="currentColor" stroke="currentColor" width="24" role="presentation" alt="" data-testid="heartspark" color="currentColor" size="24">
-                                        <g class="hearts">
-                                            <path ></path>
-                                            <path ></path>
-                                        </g>
-                                        <g class="sparks">
-                                            <path ></path>
-                                            <path ></path>
-                                        <path ></path>
-                                        <path ></path>
-                                        </g>
-                                    </svg>
-                                </button>
                             </div>
                         </div>
-                    </div>
+                    </a>
                 </body>
             </html>
         """
+        self.items = find_items(BeautifulSoup(
+            self.mock_response, 'lxml'), "sc-1bsju6x-1")
 
-    def test_check_items(self):
-        item_costs = check_items(self.mock_response)
+        item_costs = get_items(self.items)
         item_costs['Item 1 (Normal)'] = item_costs['Item 1 (Normal)'].strip()
 
         self.assertEqual(item_costs, {'Item 1 (Normal)': '800 Platinum Points',
                          'Item 2 (Sold Out)': 'Sold Out'})
 
-    def test_check_items_css_error(self):
-        self.mock_response = "<html></html>"  # Simulate no items found
-
-        with self.assertRaises(CSSTagSelectorError) as cm:
-            check_items(self.mock_response)
-        exception_message = str(cm.exception)
-        self.assertEqual(
-            exception_message, "The CSS tag for items have changed.")
-
-    def test_check_items_css_price_error(self):
+    def test_get_items_css_price_error(self):
         self.mock_response = """
             <html>
                 <body>
-                    <div class="sc-1bsju6x-4 eJevZe">
-                        <div class="sc-1bsju6x-6 irzLJU">
-                            <div class="sc-eg7slj-1 ieWZCg" style="color: rgb(72, 72, 72);">
-                                <h2 class="sc-s17bth-0 bMmuUN sc-w55g5t-0 gSthvS sc-eg7slj-2 iiGOlC">Item 1 (Normal)</h2>
-                                <div class="sc-m1loqs-5 bvcBeK"></div>
-                            </div>
-                            <div class="CHANGED_TAG">Exclusive</div>
-                            <div class="sc-m1loqs-3 gGJMHZ">
-                                <div class="sc-1f0n8u6-0 kNfSFq">
-                                    <div class="sc-1f0n8u6-1 icpwvf">
-                                        <span class="sc-1f0n8u6-5 fpvyxr">
-                                            <span class="sc-1gv8hi6-0 lktkyu sc-1f0n8u6-2 bFvx">Regular Price:</span>
-                                            <div data-testid="platinumPoints" class="sc-1f0n8u6-8 ftpArF">
-                                                <div class="sc-1244ond-0 bYKqUR sc-1yh2edi-0 GtTvR sc-1f0n8u6-7 gcszdM">
-                                                    <img alt="" loading="lazy" fetchpriority="low" class="sc-1244ond-1 eaPLXy" src="IMAGE_URL">
+                    <a class="sc-1bsju6x-1">
+                        <div class="sc-1bsju6x-4 eJevZe">
+                            <div class="sc-1bsju6x-6 irzLJU">
+                                <div class="sc-eg7slj-1 ieWZCg" style="color: rgb(72, 72, 72);">
+                                    <h2 class="sc-s17bth-0 bMmuUN sc-w55g5t-0 gSthvS sc-eg7slj-2 iiGOlC">Item 1 (Normal)</h2>
+                                    <div class="sc-m1loqs-5 bvcBeK"></div>
+                                </div>
+                                <div class="CHANGED_TAG">Exclusive</div>
+                                <div class="sc-m1loqs-3 gGJMHZ">
+                                    <div class="sc-1f0n8u6-0 kNfSFq">
+                                        <div class="sc-1f0n8u6-1 icpwvf">
+                                            <span class="sc-1f0n8u6-5 fpvyxr">
+                                                <span class="sc-1gv8hi6-0 lktkyu sc-1f0n8u6-2 bFvx">Regular Price:</span>
+                                                <div data-testid="platinumPoints" class="sc-1f0n8u6-8 ftpArF">
+                                                    <div class="sc-1244ond-0 bYKqUR sc-1yh2edi-0 GtTvR sc-1f0n8u6-7 gcszdM">
+                                                        <img alt="" loading="lazy" fetchpriority="low" class="sc-1244ond-1 eaPLXy" src="IMAGE_URL">
+                                                    </div>
+                                                    <span class="sc-1f0n8u6-10 imlIYl">
+                                                        <span class="sc-1f0n8u6-9 unbAu">800</span> Platinum Points
+                                                    </span>
                                                 </div>
-                                                <span class="sc-1f0n8u6-10 imlIYl">
-                                                    <span class="sc-1f0n8u6-9 unbAu">800</span> Platinum Points
-                                                </span>
-                                            </div>
-                                        </span>
+                                            </span>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="sc-eg7slj-0 cstaaz">
-                                <div class="sc-v8r1lj-1 UbrcP">
-                                    <div class="sc-v8r1lj-0 dQBnrT"></div>
-                                    <span>Exclusives</span>
+                                <div class="sc-eg7slj-0 cstaaz">
+                                    <div class="sc-v8r1lj-1 UbrcP">
+                                        <div class="sc-v8r1lj-0 dQBnrT"></div>
+                                        <span>Exclusives</span>
+                                    </div>
+                                    <button class="sc-1ud0cp0-0 jhpscK sc-m1loqs-0 jgyRXQ" title="Add to Wish List" aria-label="Add to Wish List" aria-pressed="false">
+                                        <svg viewBox="0 0 54 54" fill="currentColor" stroke="currentColor" width="24" role="presentation" alt="" data-testid="heartspark" color="currentColor" size="24">
+                                            <g class="hearts">
+                                                <path ></path>
+                                                <path ></path>
+                                            </g>
+                                            <g class="sparks">
+                                                <path ></path>
+                                                <path ></path>
+                                            <path ></path>
+                                            <path ></path>
+                                            </g>
+                                        </svg>
+                                    </button>
                                 </div>
-                                <button class="sc-1ud0cp0-0 jhpscK sc-m1loqs-0 jgyRXQ" title="Add to Wish List" aria-label="Add to Wish List" aria-pressed="false">
-                                    <svg viewBox="0 0 54 54" fill="currentColor" stroke="currentColor" width="24" role="presentation" alt="" data-testid="heartspark" color="currentColor" size="24">
-                                        <g class="hearts">
-                                            <path ></path>
-                                            <path ></path>
-                                        </g>
-                                        <g class="sparks">
-                                            <path ></path>
-                                            <path ></path>
-                                        <path ></path>
-                                        <path ></path>
-                                        </g>
-                                    </svg>
-                                </button>
                             </div>
                         </div>
-                    </div>
+                    </a>
                 </body>
             </html>
         """
+        self.items = find_items(BeautifulSoup(
+            self.mock_response, 'lxml'), "sc-1bsju6x-1")
 
         with self.assertRaises(CSSTagSelectorError) as cm:
-            check_items(self.mock_response)
+            get_items(self.items)
         exception_message = str(cm.exception)
         self.assertEqual(
             exception_message, "The CSS tag for stock has changed.")


### PR DESCRIPTION
Now that Selenium is being utilized, images can also be scraped from the website. 

Before with the use of only BeautifulSoup and the Requests library, the image elements weren't accessible at the time of initial request to the My Nintendo rewards website. 

With this PR, this application will be able to return the scraped images in the API requests. The next feature to be added will be displaying them on the frontend. There is consideration in storing the images in the database, but that is further down the roadmap. 

<img width="458" alt="image" src="https://github.com/samau3/mynintendo-scraper/assets/69769431/d89eb81e-63c3-4602-93d8-00836365800a">
