### PR TITLE
Update Scrape button CSS

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -15,15 +15,5 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script type="module" src="./src/index.tsx"></script>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/app/src/components/Items.tsx
+++ b/app/src/components/Items.tsx
@@ -112,25 +112,27 @@ export default function Items() {
               Last Checked:{" "}
               {new Date(scrapeResults.recent_change.timestamp).toLocaleString()}
             </p>
-            <button
-              className={`uppercase text-sm font-bold p-2 m-2 ${
-                loading
-                  ? "bg-blue-100 text-blue-400"
-                  : "bg-blue-200 text-blue-600"
-              } rounded-lg`}
-              onClick={loadScrapeResults}
-              disabled={loading}
-            >
-              {loading ? LOADING_SPINNER : "Scrape Again"}
-            </button>
-            <button className="uppercase text-sm font-bold text-blue-600 p-2 m-2 bg-blue-200 rounded-lg">
-              <a
-                href="https://www.nintendo.com/store/exclusives/rewards/"
-                target="_blank"
+            <div className="flex justify-center gap-4 flex-wrap">
+              <button
+                className={`flex justify-center flex-1 max-w-xs uppercase text-sm font-bold xs:max-h-11 p-3 m-2 ${
+                  loading
+                    ? "bg-blue-100 text-blue-400"
+                    : "bg-blue-200 text-blue-600"
+                } rounded-lg`}
+                onClick={loadScrapeResults}
+                disabled={loading}
               >
-                Check the listings
-              </a>
-            </button>
+                {loading ? LOADING_SPINNER : "Scrape Again"}
+              </button>
+              <button className="flex-1 max-w-xs uppercase text-sm font-bold text-blue-600 p-3 m-2 bg-blue-200 rounded-lg">
+                <a
+                  href="https://www.nintendo.com/store/exclusives/rewards/"
+                  target="_blank"
+                >
+                  Check the listings
+                </a>
+              </button>
+            </div>
           </div>
           <Changes
             recentChange={scrapeResults.recent_change}

--- a/app/src/components/Items.tsx
+++ b/app/src/components/Items.tsx
@@ -16,6 +16,25 @@ interface IScrapeResults {
 
 const API_STATUS_URL = "https://j50pzswk.status.cron-job.org/";
 
+const LOADING_SPINNER = (
+  <svg
+    aria-hidden="true"
+    className="w-6 h-6 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
+    viewBox="0 0 100 101"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+      fill="currentColor"
+    />
+    <path
+      d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+      fill="currentFill"
+    />
+  </svg>
+);
+
 export default function Items() {
   const [scrapeResults, setScrapeResults] = useState<
     IScrapeResults | undefined
@@ -102,26 +121,7 @@ export default function Items() {
               onClick={loadScrapeResults}
               disabled={loading}
             >
-              {loading ? (
-                <svg
-                  aria-hidden="true"
-                  className="w-6 h-6 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600"
-                  viewBox="0 0 100 101"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
-                    fill="currentColor"
-                  />
-                  <path
-                    d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
-                    fill="currentFill"
-                  />
-                </svg>
-              ) : (
-                "Scrape Again"
-              )}
+              {loading ? LOADING_SPINNER : "Scrape Again"}
             </button>
             <button className="uppercase text-sm font-bold text-blue-600 p-2 m-2 bg-blue-200 rounded-lg">
               <a
@@ -136,7 +136,10 @@ export default function Items() {
             recentChange={scrapeResults.recent_change}
             lastChange={scrapeResults.last_change}
           ></Changes>
-          <ItemGrid listings={scrapeResults.current_listings} imageURLs={scrapeResults.images} />
+          <ItemGrid
+            listings={scrapeResults.current_listings}
+            imageURLs={scrapeResults.images}
+          />
         </div>
       )}
     </>

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require('tailwindcss/defaultTheme')
+
 module.exports = {
   content: [
     "./index.html",
@@ -6,6 +8,10 @@ module.exports = {
   ],
   darkMode: 'selector',
   theme: {
+    screens: {
+      'xs': '445px',
+      ...defaultTheme.screens,
+    },
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
The height of the `Scrape Again` button would change height when switching between the loading spinner `svg` and the text "scrape again". To prevent this, padding was increased and a max height of the button was set. 

Before:
![Before button changes](https://github.com/samau3/mynintendo-scraper/assets/69769431/5414fd65-3fc6-4a54-8cdf-1aaa11ac9621)

After:
![After button changes](https://github.com/samau3/mynintendo-scraper/assets/69769431/31f12e85-458c-46a7-8a2e-87e2c54b9f1f)
