### PR TITLE
Increase Gunicorn Thread Count

### DIFF
--- a/server/dockerfile
+++ b/server/dockerfile
@@ -21,4 +21,4 @@ RUN apt-get update && apt-get -y install google-chrome-stable
 
 EXPOSE 8080
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8080", "app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "-w", "1", "--threads", "4", "app:app"]


### PR DESCRIPTION
The deployed application has a lot of latency issues when receiving multiple concurrent requests. To reduce latency, the number of threads is increased.