### PR TITLE
Enhance Logging and Load More Button Handling

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -74,10 +74,9 @@ def load_items():
                 message="Scraping timedout, CSS tags need to be updated."
             )
 
-        except TimeoutException:
+        except TimeoutException as e:
+            logging.error(e.msg)
             break
-
-    
 
     soup = BeautifulSoup(driver.page_source, 'lxml')
 


### PR DESCRIPTION
The MyNintendo Rewards page hides some items from being shown on the main listing page behind a 'See All" button if there's too many items. To make sure the web scraping of items stays accurate, this PR adds functionality to click the button if it is present on the page. In addition, this PR adds the use of the `logging` module to better trace what is happening with the API. 