### PR TITLE
Fix See All Button CSS Selecting

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -25,7 +25,8 @@ from helpers.find_items import find_items
 import dotenv
 dotenv.load_dotenv()
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(levelname)s - %(message)s')
 
 
 MYNINTENDO_URL = "https://www.nintendo.com/store/exclusives/rewards/"
@@ -51,32 +52,33 @@ def load_items():
     )
 
     # Add a check for a see more button to load more items
-    while True:
+
+    parent_div = driver.find_element(
+        By.CLASS_NAME, PARENT_CONTAINER_OF_PRODUCTS_CSS_TAG)
+    child_divs = parent_div.find_elements(By.TAG_NAME, 'div')
+
+    # Check if the number of child divs is greater than usual (e.g., expecting more than a certain number)
+    if len(child_divs) > EXPECTED_CHILD_DIV_COUNT:
+        # Break the loop if the number of child divs is not greater than expected
+
         try:
-            parent_div = driver.find_element(By.CLASS_NAME, PARENT_CONTAINER_OF_PRODUCTS_CSS_TAG)
-            child_divs = parent_div.find_elements(By.TAG_NAME, 'div')
-
-            # Check if the number of child divs is greater than usual (e.g., expecting more than a certain number)
-            if len(child_divs) <= EXPECTED_CHILD_DIV_COUNT:
-                # Break the loop if the number of child divs is not greater than expected
-                break
-
             logging.info("Found more items to load.")
             load_more_button = WebDriverWait(driver, 3).until(
-                EC.element_to_be_clickable((By.CSS_SELECTOR, 'div.sc-1egu3fv-1 button.MFcmt')),
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, 'div.sc-1egu3fv-1.cCkfGx button.MFcmt._3LMnG.xN-5A')),
                 message="Scraping timedout, CSS tag for 'See All' button needs to be updated."
             )
             load_more_button.click()
-            logging.info("'Load More' button clicked.")
+            logging.info("'See All' button clicked.")
             # Wait for additional items to load
             WebDriverWait(driver, 10).until(
-                EC.presence_of_all_elements_located((By.CLASS_NAME, ITEMS_CSS_TAG)),
+                EC.presence_of_all_elements_located(
+                    (By.CLASS_NAME, ITEMS_CSS_TAG)),
                 message="Scraping timedout, CSS tags need to be updated."
             )
 
         except TimeoutException as e:
             logging.error(e.msg)
-            break
 
     soup = BeautifulSoup(driver.page_source, 'lxml')
 


### PR DESCRIPTION
This PR better specifies which button to click due to multiple buttons having a shared class. In addition, this PR removes the use of a loop to check for more 'See All' buttons due to clicking the button loading all items.