### PR TITLE
feat(ui): cached load flow, a11y polish, and manifest updates

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,10 +1,21 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="MyNintendo Scraper" />
+    <meta name="theme-color" content="#1e293b" />
+    <meta
+      name="description"
+      content="Monitor My Nintendo rewards store listings and detect changes in real time."
+    />
+    <meta property="og:title" content="MyNintendo Scraper" />
+    <meta
+      property="og:description"
+      content="Full-stack web scraper that monitors My Nintendo rewards listings, detects changes, and sends Discord alerts."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://mynintendo-scraper.vercel.app/" />
+    <link rel="manifest" href="/manifest.json" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/app/public/manifest.json
+++ b/app/public/manifest.json
@@ -1,25 +1,16 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "MyNintendo",
+  "name": "MyNintendo Scraper",
+  "description": "Monitor My Nintendo rewards store listings and detect changes.",
   "icons": [
     {
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "theme_color": "#1e293b",
+  "background_color": "#fbbf24"
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,35 +15,45 @@ function App() {
     IScrapeResults | undefined
   >(undefined);
   const [errorInfo, setErrorInfo] = useState<string | undefined>(undefined);
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [hasLoadedCache, setHasLoadedCache] = useState<boolean>(false);
 
-  const shouldShowLoading = !scrapeResults && !errorInfo;
+  const shouldShowLoading = loading && !scrapeResults;
 
   useEffect(() => {
-    loadScrapeResults();
+    loadCachedResults();
   }, []);
 
-  async function loadScrapeResults() {
-    setLoading((prev) => !prev);
+  async function loadCachedResults() {
+    setLoading(true);
     try {
-      const results = await MyNintendoScraperAPI.getItems();
-      setScrapeResults(results);
-      setLoading((prev) => !prev);
-      if (errorInfo) {
+      const cached = await MyNintendoScraperAPI.getCachedItems();
+      if (cached) {
+        setScrapeResults(cached);
         setErrorInfo(undefined);
       }
     } catch (error: unknown) {
-      let message = "Something went wrong.";
-      if (error instanceof Error) {
-        message = error.message;
-      } else {
-        console.error(error);
-      }
+      const message =
+        error instanceof Error ? error.message : "Something went wrong.";
       setErrorInfo(message);
+    } finally {
+      setLoading(false);
+      setHasLoadedCache(true);
+    }
+  }
 
-      if (scrapeResults) {
-        setScrapeResults(undefined);
-      }
+  async function scrapeAgain() {
+    setLoading(true);
+    try {
+      const results = await MyNintendoScraperAPI.scrapeItems();
+      setScrapeResults(results);
+      setErrorInfo(undefined);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : "Something went wrong.";
+      setErrorInfo(message);
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -59,7 +69,7 @@ function App() {
         </div>
       </div>
       <div className="absolute top-0 z-10 flex min-h-screen min-w-full flex-col items-center p-4">
-        <div className="right-5 top-5 flex w-full flex-row-reverse sm:absolute sm:w-min">
+        <div className="top-5 right-5 flex w-full flex-row-reverse sm:absolute sm:w-min">
           <ThemeSwitcher />
         </div>
         <div>
@@ -77,8 +87,22 @@ function App() {
           <Items
             items={scrapeResults}
             loading={loading}
-            loadScrapeResults={loadScrapeResults}
+            loadScrapeResults={scrapeAgain}
           />
+        )}
+
+        {!scrapeResults && !errorInfo && hasLoadedCache && !loading && (
+          <div className="mt-10 text-center">
+            <p className="mb-4 dark:text-slate-300">
+              No cached listings found. Run a scrape to fetch current items.
+            </p>
+            <button
+              className="rounded-lg bg-blue-200 px-6 py-3 text-sm font-bold text-blue-600 uppercase"
+              onClick={scrapeAgain}
+            >
+              Scrape Now
+            </button>
+          </div>
         )}
       </div>
     </>

--- a/app/src/api/myNintendoScraperAPI.ts
+++ b/app/src/api/myNintendoScraperAPI.ts
@@ -1,27 +1,39 @@
 import { BACKEND_BASE_URL } from "../config";
+import type { IScrapeResults } from "../interfaces/interfaces";
+
+async function parseErrorResponse(rawResponse: Response): Promise<string> {
+  let errorMessage = "An unexpected error occurred.";
+  try {
+    const errorResponse = await rawResponse.json();
+    if (errorResponse?.message) {
+      errorMessage = errorResponse.message;
+    }
+  } catch {
+    const textError = await rawResponse.text();
+    if (textError) {
+      errorMessage = textError;
+    }
+  }
+  return errorMessage;
+}
 
 export class MyNintendoScraperAPI {
-  static async getItems() {
+  static async getCachedItems(): Promise<IScrapeResults | null> {
+    const rawResponse = await fetch(`${BACKEND_BASE_URL}api/items/latest`);
+    if (rawResponse.status === 404) {
+      return null;
+    }
+    if (!rawResponse.ok) {
+      throw new Error(await parseErrorResponse(rawResponse));
+    }
+    return rawResponse.json();
+  }
+
+  static async scrapeItems(): Promise<IScrapeResults> {
     const rawResponse = await fetch(BACKEND_BASE_URL);
     if (!rawResponse.ok) {
-      let errorMessage = "An unexpected error occurred.";
-      try {
-        // Attempt to parse the error response as JSON
-        const errorResponse = await rawResponse.json();
-
-        if (errorResponse && errorResponse.message) {
-          errorMessage = errorResponse.message;
-        }
-      } catch (jsonError) {
-        // If parsing fails, attempt to use text response or fallback to default message
-        const textError = await rawResponse.text();
-        if (textError) {
-          errorMessage = textError;
-        }
-      }
-      throw new Error(errorMessage);
+      throw new Error(await parseErrorResponse(rawResponse));
     }
-    const response = await rawResponse.json();
-    return response;
+    return rawResponse.json();
   }
 }

--- a/app/src/components/Changes.tsx
+++ b/app/src/components/Changes.tsx
@@ -8,8 +8,8 @@ interface ChangesProps {
 
 export default function Changes({ recentChange, lastChange }: ChangesProps) {
   return (
-    <div className="mb-3 grid grid-cols-2 gap-x-3">
-      <div className="flex-1 rounded-md bg-gray-100 bg-opacity-30 p-2 dark:bg-slate-800 dark:bg-opacity-70">
+    <div className="mb-3 grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-x-3">
+      <div className="bg-opacity-30 dark:bg-opacity-70 flex-1 rounded-md bg-gray-100 p-2 dark:bg-slate-800">
         <p className="dark:text-slate-300">Latest Scrape Results:</p>
         {typeof recentChange.items === "string" ? (
           <>
@@ -17,7 +17,7 @@ export default function Changes({ recentChange, lastChange }: ChangesProps) {
               {recentChange.items}
             </p>
             <section className="flex flex-col items-center">
-              <p className="mb-6 mt-6 text-lg dark:text-slate-300">
+              <p className="mt-6 mb-6 text-lg dark:text-slate-300">
                 As of{" "}
                 <span className="font-bold">
                   {new Date(recentChange.timestamp).toLocaleString()}
@@ -31,12 +31,20 @@ export default function Changes({ recentChange, lastChange }: ChangesProps) {
           <ChangedItemsList changedItemsData={recentChange.items} />
         )}
       </div>
-      <div className="flex-1 rounded-md bg-gray-100 bg-opacity-30 p-2 dark:bg-slate-800 dark:bg-opacity-70">
+      <div className="bg-opacity-30 dark:bg-opacity-70 flex-1 rounded-md bg-gray-100 p-2 dark:bg-slate-800">
         <p className="dark:text-slate-300">Last Change:</p>
-        <ChangedItemsList changedItemsData={lastChange.items} />
-        <p className="font-bold dark:text-slate-300">
-          From {new Date(lastChange.timestamp).toLocaleString()}
-        </p>
+        {Object.keys(lastChange.items).length > 0 ? (
+          <ChangedItemsList changedItemsData={lastChange.items} />
+        ) : (
+          <p className="text-lg dark:text-slate-300">
+            No changes recorded yet.
+          </p>
+        )}
+        {lastChange.timestamp && (
+          <p className="font-bold dark:text-slate-300">
+            From {new Date(lastChange.timestamp).toLocaleString()}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/app/src/components/ErrorView.tsx
+++ b/app/src/components/ErrorView.tsx
@@ -20,7 +20,7 @@ export default function ErrorView({ errorInfo }: ErrorViewProps) {
         </a>
         .
       </p>
-      <button className="m-2 rounded-lg bg-blue-100 p-2 text-sm font-bold uppercase text-blue-600">
+      <button className="m-2 rounded-lg bg-blue-100 p-2 text-sm font-bold text-blue-600 uppercase">
         <a href={API_STATUS_URL} target="_blank">
           API Status
         </a>

--- a/app/src/components/ItemCard.tsx
+++ b/app/src/components/ItemCard.tsx
@@ -9,9 +9,11 @@ export function ItemCard({ item, index, cost, imageURL }: ItemCardProps) {
   return (
     <div
       key={`${item}-${index}`}
-      className="flex h-full w-full flex-col justify-between rounded-lg border-2 bg-gray-100 bg-opacity-80 p-4 shadow-lg dark:border-gray-600 dark:bg-slate-800 dark:bg-opacity-80"
+      className="bg-opacity-80 dark:bg-opacity-80 flex h-full w-full flex-col justify-between rounded-lg border-2 bg-gray-100 p-4 shadow-lg dark:border-gray-600 dark:bg-slate-800"
     >
-      {imageURL && <img className="mb-2" src={imageURL} />}
+      {imageURL && (
+        <img className="mb-2" src={imageURL} alt={`${item} product image`} />
+      )}
       <p className="mb-auto text-lg tracking-tight text-black dark:text-slate-200">
         {item}
       </p>

--- a/app/src/components/Items.tsx
+++ b/app/src/components/Items.tsx
@@ -25,7 +25,7 @@ export default function Items({
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <button
-              className={`m-2 flex max-w-xs flex-1 justify-center p-3 text-sm font-bold uppercase xs:max-h-11 ${
+              className={`xs:max-h-11 m-2 flex max-w-xs flex-1 justify-center p-3 text-sm font-bold uppercase ${
                 loading
                   ? "bg-blue-100 text-blue-400"
                   : "bg-blue-200 text-blue-600"
@@ -35,7 +35,7 @@ export default function Items({
             >
               {loading ? <LoadingSVG /> : "Scrape Again"}
             </button>
-            <button className="m-2 max-w-xs flex-1 rounded-lg bg-blue-200 p-3 text-sm font-bold uppercase text-blue-600">
+            <button className="m-2 max-w-xs flex-1 rounded-lg bg-blue-200 p-3 text-sm font-bold text-blue-600 uppercase">
               <a
                 href="https://www.nintendo.com/store/exclusives/rewards/"
                 target="_blank"

--- a/app/src/components/ThemeSwitcher.tsx
+++ b/app/src/components/ThemeSwitcher.tsx
@@ -21,8 +21,10 @@ const ThemeSwitcher = () => {
 
   return (
     <button
+      type="button"
       onClick={toggleDarkMode}
-      className="rounded-md bg-slate-800 px-4 py-2 text-white dark:bg-slate-400"
+      aria-label="Toggle dark mode"
+      className="rounded-md bg-slate-800 px-4 py-2 text-white focus:ring-2 focus:ring-blue-400 focus:outline-none dark:bg-slate-400"
     >
       {darkMode ? (
         <SunIcon className="h-6 w-6 text-yellow-400"></SunIcon>

--- a/app/src/interfaces/interfaces.ts
+++ b/app/src/interfaces/interfaces.ts
@@ -12,9 +12,9 @@ export interface IChanges {
 }
 
 export interface ILastChange {
-  expiration: string;
+  expiration: string | null;
   items: IScrapedItems;
-  timestamp: string;
+  timestamp: string | null;
 }
 
 export interface IScrapeResults {


### PR DESCRIPTION
Updates the frontend to load cached listings from `GET /api/items/latest` on page load, with a manual “Scrape Again” action that triggers a live scrape via GET /. Refactors the API client into separate cached and scrape methods and fixes loading state handling with explicit `try/finally` blocks so errors can’t leave the UI stuck. Also includes accessibility and polish updates: theme toggle `aria-label`, meaningful image alt text, a responsive changes layout, updated manifest.json, and Open Graph meta tags in `index.html`.