### PR TITLE
fix(server): store product images for cache listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,18 @@ npm run format:check
 
 Manual Fly.io deploy: `cd server && flyctl deploy --remote-only`
 
+### Database migrations
+
+The app uses `db.create_all()` and does not run automatic schema migrations. When deploying a change that adds columns to existing tables, run the required SQL against your PostgreSQL database before or after deploy.
+
+**Product images column** (required for cached listing images):
+
+```sql
+ALTER TABLE item_listings ADD COLUMN IF NOT EXISTS images JSON NOT NULL DEFAULT '{}';
+```
+
+Existing rows will have empty image maps until the next scrape or cron run populates them.
+
 External cron jobs (configured at [cron-job.org](https://cron-job.org)):
 - Hourly: `GET /api/scrape`
 - Weekly: `GET /api/delete`

--- a/server/app.py
+++ b/server/app.py
@@ -56,7 +56,7 @@ def display_scrape_summary():
     raw_item_elements = load_items()
     items = get_items(raw_item_elements)
     images = get_item_images(raw_item_elements)
-    scrape_results = scrape_mynintendo(items)
+    scrape_results = scrape_mynintendo(items, images)
     last_change = get_changes()
 
     if scrape_results["items"] != "No changes.":

--- a/server/main.py
+++ b/server/main.py
@@ -181,7 +181,7 @@ def get_latest_listings_summary():
 
     return {
         "current_listings": last_record.items,
-        "images": {},
+        "images": last_record.images or {},
         "recent_change": {
             "items": "No changes.",
             "timestamp": last_record.timestamp,
@@ -190,7 +190,7 @@ def get_latest_listings_summary():
     }
 
 
-def scrape_mynintendo(current_items):
+def scrape_mynintendo(current_items, images=None):
     """Function that calls scraping function and updates database if changes were found"""
     last_record = Listings.query.order_by(Listings.id.desc()).first()
     last_items = last_record.items if last_record is not None else {}
@@ -199,7 +199,7 @@ def scrape_mynintendo(current_items):
 
     if changes:
         Changes.add_record(changes)
-    new_item = Listings.add_record(current_items)
+    new_item = Listings.add_record(current_items, images=images or {})
 
     try:
         db.session.commit()

--- a/server/models.py
+++ b/server/models.py
@@ -15,16 +15,19 @@ class Listings(db.Model):
     timestamp = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     expiration = db.Column(db.DateTime, nullable=False)
     items = db.Column(db.JSON, nullable=False)
+    images = db.Column(db.JSON, nullable=False, default=dict)
 
-    def __init__(self, items, expiration=None):
+    def __init__(self, items, images=None, expiration=None):
         self.items = items
+        self.images = images if images is not None else {}
         self.expiration = expiration if expiration else calculate_expiration_date(7)
 
     @classmethod
-    def add_record(self, items):
+    def add_record(self, items, images=None):
         """Store the scrapped items into database"""
         item = Listings(
             items=items,
+            images=images,
         )
         db.session.add(item)
         return item

--- a/server/routes/main_api.py
+++ b/server/routes/main_api.py
@@ -2,6 +2,7 @@ from flask import Blueprint, jsonify
 
 from main import (
     delete_old_records,
+    get_item_images,
     get_items,
     get_latest_listings_summary,
     load_items,
@@ -23,7 +24,8 @@ def call_scrape_fn():
 
     raw_item_elements = load_items()
     items = get_items(raw_item_elements)
-    results = scrape_mynintendo(items)
+    images = get_item_images(raw_item_elements)
+    results = scrape_mynintendo(items, images)
 
     if results["items"] != "No changes.":
         message_discord(results["items"])

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -10,9 +10,22 @@ def test_listings_add_record_sets_expiration(app):
         db.session.commit()
 
         assert record.items == {"Item A": "100 Platinum Points"}
+        assert record.images == {}
         assert record.expiration is not None
         assert record.expiration > record.timestamp
         assert Listings.query.count() == 1
+
+
+def test_listings_add_record_stores_images(app):
+    with app.app_context():
+        images = {"Item A": "https://assets.nintendo.com/item-a.png"}
+        record = Listings.add_record(
+            {"Item A": "100 Platinum Points"},
+            images=images,
+        )
+        db.session.commit()
+
+        assert record.images == images
 
 
 def test_changes_add_record(app):

--- a/server/tests/test_routes.py
+++ b/server/tests/test_routes.py
@@ -24,13 +24,17 @@ def test_get_items_latest_returns_404_when_empty(client):
 
 def test_get_items_latest_returns_cached_listings(app, client):
     with app.app_context():
-        Listings.add_record({"Item A": "100 Platinum Points"})
+        Listings.add_record(
+            {"Item A": "100 Platinum Points"},
+            images={"Item A": "https://assets.nintendo.com/item-a.png"},
+        )
         db.session.commit()
 
     response = client.get("/api/items/latest")
     assert response.status_code == 200
     data = response.get_json()
     assert data["current_listings"] == {"Item A": "100 Platinum Points"}
+    assert data["images"] == {"Item A": "https://assets.nintendo.com/item-a.png"}
     assert data["recent_change"]["items"] == "No changes."
 
 


### PR DESCRIPTION
With the change to use cache listings on page load, the database did not have product images being stored. This PR now adds an image key to be stored along with the rest of the product data. 