### PR TITLE
fix(server): switch to domcontentloaded for playwright waiting

### DIFF
--- a/server/helpers/expand_rewards_list.py
+++ b/server/helpers/expand_rewards_list.py
@@ -90,7 +90,6 @@ def expand_rewards_list(page, product_ready_selector):
 
         button.scroll_into_view_if_needed()
         button.click()
-        page.wait_for_load_state("networkidle")
         page.wait_for_selector(product_ready_selector, timeout=10000)
 
         count_after, expanded = wait_for_expansion(page, count_before)

--- a/server/main.py
+++ b/server/main.py
@@ -112,7 +112,7 @@ def load_items():
         page = browser.new_page()
         try:
             page.set_default_timeout(30000)  # 30 seconds
-            page.goto(MYNINTENDO_URL, wait_until="networkidle")
+            page.goto(MYNINTENDO_URL, wait_until="domcontentloaded")
             page.wait_for_selector(PRODUCT_READY_SELECTOR, timeout=20000)
             expansion_meta = expand_rewards_list(page, PRODUCT_READY_SELECTOR)
             soup = BeautifulSoup(page.content(), "lxml")


### PR DESCRIPTION
To try to reduce the failures of web scrape attempts, switch to `domcontentloaded` instead of `networkidle`